### PR TITLE
feat: check PR has backport information

### DIFF
--- a/spec/fixtures/pull_request.opened.json
+++ b/spec/fixtures/pull_request.opened.json
@@ -1,0 +1,36 @@
+{
+  "name": "pull_request",
+  "payload": {
+    "action": "opened",
+    "number": 7,
+    "pull_request": {
+      "url": "my_cool_url",
+      "title": "CHANGE README",
+      "merged": true,
+      "user": {
+        "login": "codebytere"
+      },
+      "body": "New cool stuff",
+      "labels": [],
+      "head": {
+        "sha": "ABC"
+      },
+      "base": {
+        "ref": "master"
+      }
+    },
+    "label": {
+      "name": "todo",
+      "color": "8cb728"
+    },
+    "repository": {
+      "name": "probot-test",
+      "owner": {
+        "login": "codebytere"
+      }
+    },
+    "installation": {
+      "id": 103619
+    }
+  }
+}

--- a/spec/index.spec.ts
+++ b/spec/index.spec.ts
@@ -1,4 +1,8 @@
 jest.mock('request');
+
+import { promises as fs } from 'fs';
+import { posix as path } from 'path';
+
 import { Application } from 'probot';
 
 import { labelClosedPR, getPRNumbersFromPRBody } from '../src/utils';
@@ -8,7 +12,9 @@ import {
 } from '../src/operations/backport-to-location';
 import { updateManualBackport } from '../src/operations/update-manual-backport';
 import { ProbotHandler } from '../src/index';
-import { PRChange } from '../src/enums';
+import { CheckRunStatus, PRChange } from '../src/enums';
+
+import * as checkUtils from '../src/utils/checks-util';
 
 const trop: ProbotHandler = require('../src/index');
 
@@ -25,6 +31,22 @@ const backportPRMergedEvent = require('./fixtures/backport_pull_request.merged.j
 const backportPRClosedEvent = require('./fixtures/backport_pull_request.closed.json');
 const backportPROpenedEvent = require('./fixtures/backport_pull_request.opened.json');
 
+const newPROpenedEventPath = path.join(
+  __dirname,
+  'fixtures',
+  'pull_request.opened.json',
+);
+
+const noBackportLabel = {
+  name: 'no-backport',
+  color: '000',
+};
+
+const targetLabel = {
+  name: 'target/12-x-y',
+  color: 'fff',
+};
+
 jest.mock('../src/utils', () => ({
   labelClosedPR: jest.fn(),
   isAuthorizedUser: jest.fn().mockReturnValue(Promise.resolve([true])),
@@ -40,15 +62,19 @@ jest.mock('../src/operations/backport-to-location', () => ({
   backportToLabel: jest.fn(),
 }));
 
+jest.mock('../src/utils/checks-util', () => ({
+  updateBackportValidityCheck: jest.fn(),
+  getBackportInformationCheck: jest.fn().mockReturnValue(Promise.resolve()),
+  updateBackportInformationCheck: jest.fn().mockReturnValue(Promise.resolve()),
+  queueBackportInformationCheck: jest.fn().mockReturnValue(Promise.resolve()),
+}));
+
 describe('trop', () => {
   let robot: Application;
   let github: any;
   process.env = { BOT_USER_NAME: 'trop[bot]' };
 
   beforeEach(() => {
-    robot = new Application();
-    robot.load(trop);
-
     github = {
       repos: {
         getBranch: jest.fn().mockReturnValue(Promise.resolve()),
@@ -104,10 +130,13 @@ describe('trop', () => {
         listForRef: jest
           .fn()
           .mockReturnValue(Promise.resolve({ data: { check_runs: [] } })),
+        create: jest.fn().mockReturnValue(Promise.resolve({ data: jest.fn() })),
       },
     };
 
+    robot = new Application();
     robot.auth = () => Promise.resolve(github);
+    robot.load(trop);
   });
 
   describe('issue_comment.created event', () => {
@@ -172,6 +201,96 @@ describe('trop', () => {
       await robot.receive(backportPROpenedEvent);
 
       expect(updateManualBackport).toHaveBeenCalled();
+    });
+
+    it('fails the check if there is no backport information for a new PR', async () => {
+      const event = JSON.parse(
+        (await fs.readFile(newPROpenedEventPath, 'utf-8')) as string,
+      );
+
+      event.payload.pull_request.labels = [];
+
+      await robot.receive(event);
+
+      const updatePayload = (checkUtils.updateBackportInformationCheck as jest.Mock)
+        .mock.calls[0][2];
+
+      expect(updatePayload).toMatchObject({
+        title: 'Missing Backport Information',
+        summary:
+          'This PR is missing the required backport information. It should have a "no-backport" or a "target/x-y-z" label.',
+        conclusion: CheckRunStatus.FAILURE,
+      });
+    });
+
+    it('fails the check if there is conflicting backport information in a new PR', async () => {
+      (getPRNumbersFromPRBody as jest.Mock).mockReturnValueOnce(
+        Promise.resolve([]),
+      );
+
+      const event = JSON.parse(
+        (await fs.readFile(newPROpenedEventPath, 'utf-8')) as string,
+      );
+
+      event.payload.pull_request.labels = [noBackportLabel, targetLabel];
+
+      await robot.receive(event);
+
+      const updatePayload = (checkUtils.updateBackportInformationCheck as jest.Mock)
+        .mock.calls[0][2];
+
+      expect(updatePayload).toMatchObject({
+        title: 'Conflicting Backport Information',
+        summary:
+          'The PR has a "no-backport" and at least one "target/x-y-z" labels. Impossible to determine backport action.',
+        conclusion: CheckRunStatus.FAILURE,
+      });
+    });
+
+    it('passes the check if there is a "no-backport" label and no "target/" label in a new PR', async () => {
+      (getPRNumbersFromPRBody as jest.Mock).mockReturnValueOnce(
+        Promise.resolve([]),
+      );
+
+      const event = JSON.parse(
+        (await fs.readFile(newPROpenedEventPath, 'utf-8')) as string,
+      );
+
+      event.payload.pull_request.labels = [noBackportLabel];
+
+      await robot.receive(event);
+
+      const updatePayload = (checkUtils.updateBackportInformationCheck as jest.Mock)
+        .mock.calls[0][2];
+
+      expect(updatePayload).toMatchObject({
+        title: 'Backport Information Provided',
+        summary: 'This PR contains the required  backport information.',
+        conclusion: CheckRunStatus.SUCCESS,
+      });
+    });
+
+    it('passes the check if there is no "no-backport" label and a "target/" label in a new PR', async () => {
+      (getPRNumbersFromPRBody as jest.Mock).mockReturnValueOnce(
+        Promise.resolve([]),
+      );
+
+      const event = JSON.parse(
+        (await fs.readFile(newPROpenedEventPath, 'utf-8')) as string,
+      );
+
+      event.payload.pull_request.labels = [targetLabel];
+
+      await robot.receive(event);
+
+      const updatePayload = (checkUtils.updateBackportInformationCheck as jest.Mock)
+        .mock.calls[0][2];
+
+      expect(updatePayload).toMatchObject({
+        title: 'Backport Information Provided',
+        summary: 'This PR contains the required  backport information.',
+        conclusion: CheckRunStatus.SUCCESS,
+      });
     });
   });
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,8 +1,12 @@
 export const CHECK_PREFIX = 'Backportable? - ';
 
+export const BACKPORT_INFORMATION_CHECK = 'Backport information?';
+
 export const NUM_SUPPORTED_VERSIONS = process.env.NUM_SUPPORTED_VERSIONS || 4;
 
 export const BACKPORT_LABEL = 'backport';
+
+export const NO_BACKPORT_LABEL = 'no-backport';
 
 export const SEMVER_PREFIX = 'semver/';
 

--- a/src/utils/checks-util.ts
+++ b/src/utils/checks-util.ts
@@ -1,6 +1,10 @@
 import { Context } from 'probot';
 import { CheckRunStatus } from '../enums';
-import { ChecksListForRefResponseCheckRunsItem } from '@octokit/rest';
+import {
+  ChecksListForRefResponseCheckRunsItem,
+  PullsGetResponse,
+} from '@octokit/rest';
+import { BACKPORT_INFORMATION_CHECK } from '../constants';
 
 export async function updateBackportValidityCheck(
   context: Context,
@@ -23,6 +27,59 @@ export async function updateBackportValidityCheck(
         title: statusItems.title,
         summary: statusItems.summary,
       },
+    }),
+  );
+}
+
+export async function getBackportInformationCheck(context: Context) {
+  const pr: PullsGetResponse = context.payload.pull_request;
+  const allChecks = await context.github.checks.listForRef(
+    context.repo({
+      ref: pr.head.sha,
+      per_page: 100,
+    }),
+  );
+
+  const backportCheck = allChecks.data.check_runs.filter((run) =>
+    run.name.startsWith(BACKPORT_INFORMATION_CHECK),
+  )[0];
+
+  return backportCheck;
+}
+
+export async function updateBackportInformationCheck(
+  context: Context,
+  backportCheck: ChecksListForRefResponseCheckRunsItem,
+  statusItems: {
+    conclusion: CheckRunStatus;
+    title: string;
+    summary: string;
+  },
+) {
+  await context.github.checks.update(
+    context.repo({
+      check_run_id: backportCheck.id,
+      name: backportCheck.name,
+      conclusion: statusItems.conclusion as CheckRunStatus,
+      completed_at: new Date().toISOString(),
+      details_url: 'https://github.com/electron/trop',
+      output: {
+        title: statusItems.title,
+        summary: statusItems.summary,
+      },
+    }),
+  );
+}
+
+export async function queueBackportInformationCheck(context: Context) {
+  const pr: PullsGetResponse = context.payload.pull_request;
+
+  await context.github.checks.create(
+    context.repo({
+      name: BACKPORT_INFORMATION_CHECK,
+      head_sha: pr.head.sha,
+      status: 'queued' as 'queued',
+      details_url: 'https://github.com/electron/trop',
     }),
   );
 }


### PR DESCRIPTION
Checks if PRs to the master branch contain backport information and
fails if not. Backport information is one of the following:

* A `no-backport` label
* A `target/x-y-z` label

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

Ref: https://github.com/electron/governance/blob/master/wg-releases/meeting-notes/2021-04-07.md